### PR TITLE
use password type for api and app key inputs

### DIFF
--- a/node-red-contrib-datadog/datadog.html
+++ b/node-red-contrib-datadog/datadog.html
@@ -29,11 +29,11 @@
     </div>
     <div class="form-row">
         <label for="node-input-apikey"><i class="icon-tag"></i>API Key</label>
-        <input type="text" id="node-input-apikey" placeholder="api-key">
+        <input type="password" id="node-input-apikey" placeholder="api-key">
     </div>
     <div class="form-row">
         <label for="node-input-appkey"><i class="icon-tag"></i>APP Key</label>
-        <input type="text" id="node-input-appkey" placeholder="app-key">
+        <input type="password" id="node-input-appkey" placeholder="app-key">
     </div>
     <div class="form-row">
         <label for="node-input-hostname"><i class="icon-tag"></i>Host Name</label>


### PR DESCRIPTION
makes it so APP and API key aren't plain text. also allows password managers (like 1Password) to suggest passwords, etc.